### PR TITLE
Introduce `getFactory` method for cached factories

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var tags = require('html-tags')
 var h = require('hyperscript')
+var instances
 
 /**
  * Returns an element factory using the given createElement function.
@@ -26,6 +27,28 @@ function createFactory (fn) {
 }
 
 /**
+ * Return an element factory function, either by creating a new one or by
+ * getting a cached version
+ *
+ * @param  {Function} fn - createElement function
+ * @return {Function} - factory function with all HTML tag factories attached
+ */
+function getFactory (fn) {
+  if (!instances) {
+    instances = new Map()
+  }
+
+  var factory = instances.get(fn)
+  if (factory) {
+    return factory
+  }
+
+  factory = createFactory(fn)
+  instances.set(fn, factory)
+  return factory
+}
+
+/**
  * Turns arguments into an array, optionally slicing off a portion.
  * @param  {array} args - arguments object (array-like)
  * @param  {number} num - optional integer for Array.slice
@@ -44,3 +67,4 @@ function isObject (val) {
 
 module.exports = createFactory(h)
 module.exports.createFactory = createFactory
+module.exports.getFactory = getFactory

--- a/test.js
+++ b/test.js
@@ -117,3 +117,13 @@ test('examples: arrays', t => {
     '<div class="arrays"><p>Once upon a time,</p><p>there was a variadic function,</p><p>that also accepted arrays.</p></div>'
   )
 })
+
+test('getFactory: cached createFactory', t => {
+  t.plan(1)
+
+  var h = require('hyperscript')
+  var y = x.getFactory(h)
+  var z = x.getFactory(h)
+
+  t.ok(y === z)
+})


### PR DESCRIPTION
This PR probably needs a bit of introduction.

To make them more portable between hyperscript implementations, I'm trying out writing my view functions using `hyperaxe` in the following way:

```js
function view (h, data) {
  var {body, h1, p} = x.createFactory(h)

  return body(
    h1(data.title),
    p(data.content)
 ) 
} 
```

However, this creates a new `hyperaxe` instance on every call, which is clearly not great. To solve this I'd like to introduce a `getFactory` function which creates a new factory the first time it's called, and returns a cached version after that.

Thanks for considering!