### PR TITLE
test: restructure test tooling and gate coverage

### DIFF
--- a/.github/workflows/fresh-deps.yml
+++ b/.github/workflows/fresh-deps.yml
@@ -23,4 +23,6 @@ jobs:
         node-version: ${{ matrix.node }}
     - run: rm package-lock.json
     - run: npm i
-    - run: npm run check
+    - run: npm test
+    - run: npm run coverage
+    - run: npm run test:pack

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,4 +22,6 @@ jobs:
         node-version: ${{ matrix.node }}
         cache: npm
     - run: npm ci
-    - run: npm run check
+    - run: npm test
+    - run: npm run coverage
+    - run: npm run test:pack

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "includes": ["src/**", "*.json"] },
+  "files": { "includes": ["src/**", "test/**"] },
   "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2, "lineWidth": 100 },
   "javascript": {
     "formatter": { "quoteStyle": "single", "semicolons": "asNeeded", "trailingCommas": "none" }

--- a/package.json
+++ b/package.json
@@ -57,16 +57,15 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "npm run lint && npm run typecheck && npm test && npx publint && npm run test:pack",
     "coverage": "node --test --experimental-test-coverage --import=tsx --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts",
     "format": "biome check --write .",
     "lint": "biome check .",
     "postrelease": "git push --follow-tags && npm publish",
     "prebuild": "rm -rf dist",
     "prepare": "npm run build",
-    "prerelease": "git fetch --tags && npm run check",
+    "prerelease": "git fetch --tags && npm test && npm run test:pack",
     "release": "npm version patch",
-    "test": "node --test --import=tsx test/*.test.ts",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test --import=tsx test/*.test.ts",
     "test:pack": "bash scripts/test-pack.sh",
     "test:watch": "node --test --watch --import=tsx test/*.test.ts",
     "typecheck": "tsc -p tsconfig.test.json"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "build": "tsc",
     "check": "npm run lint && npm run typecheck && npm test && npx publint && npm run test:pack",
+    "coverage": "node --test --experimental-test-coverage --import=tsx --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts",
     "format": "biome check --write .",
     "lint": "biome check .",
     "postrelease": "git push --follow-tags && npm publish",

--- a/package.json
+++ b/package.json
@@ -56,18 +56,19 @@
     "url": "git+https://github.com/ungoldman/hyperaxe.git"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "tsc",
     "check": "npm run lint && npm run typecheck && npm test && npx publint && npm run test:pack",
     "format": "biome check --write .",
     "lint": "biome check .",
     "postrelease": "git push --follow-tags && npm publish",
+    "prebuild": "rm -rf dist",
     "prepare": "npm run build",
     "prerelease": "git fetch --tags && npm run check",
     "release": "npm version patch",
     "test": "node --test --import=tsx test/*.test.ts",
     "test:pack": "bash scripts/test-pack.sh",
     "test:watch": "node --test --watch --import=tsx test/*.test.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.test.json"
   },
   "type": "module",
   "types": "dist/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "prepare": "npm run build",
     "prerelease": "git fetch --tags && npm run check",
     "release": "npm version patch",
-    "test": "node --test --import=tsx src/**/*.spec.ts",
+    "test": "node --test --import=tsx test/*.test.ts",
     "test:pack": "bash scripts/test-pack.sh",
-    "test:watch": "node --test --watch --import=tsx src/**/*.spec.ts",
+    "test:watch": "node --test --watch --import=tsx test/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "type": "module",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,9 +2,9 @@ import { strict as assert } from 'node:assert'
 import { describe, test } from 'node:test'
 import tags from 'html-tags'
 import h from 'hyperscript'
-import type { CreateElementFunction } from './factory.js'
-import * as namedExports from './index.js'
-import hyperaxe, { getFactory, varTag } from './index.js'
+import type { CreateElementFunction } from '../src/factory.js'
+import * as namedExports from '../src/index.js'
+import hyperaxe, { getFactory, varTag } from '../src/index.js'
 
 describe('Hyperaxe Factory', () => {
   test('factory function signature', () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": false
-  },
-  "exclude": ["src/**/*.spec.ts"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "types": ["node"],
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -22,5 +20,5 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
Reorganizes the test setup and enforces coverage in CI: specs move out of `src/` into `test/`, the single tsconfig splits into a build config and a separate `noEmit` typecheck config, and a 100% coverage gate now runs on every build.

## Changes
- Move specs from `src/` to `test/` (`index.spec.ts` to `index.test.ts`), with imports pointed at `../src` using `.js` extensions (the same NodeNext convention the source uses for its self-imports).
- `tsconfig.json` becomes the build config (emits `src`); new `tsconfig.test.json` is the `noEmit` typecheck that includes the tests. Remove `tsconfig.build.json`.
- Add a `coverage` script on Node's built-in coverage (no c8): lines, branches, and functions gated at 100%, excluding `test/`.
- `npm test` becomes the aggregate (`lint && typecheck && build && run`); drop the redundant `check` script. CI runs `npm test`, `npm run coverage`, and `npm run test:pack`, which also takes `npx publint` out of CI.
- Drop `*.json` from Biome's scope so it stops formatting `package.json` (fixpack owns that).

## Verification
`npm test`, `npm run coverage` (100%), and `npm run test:pack` pass locally.

tsx stays: native type stripping can't resolve the `.js` to `.ts` rewrite that tsc's NodeNext self-imports require (`index.ts` imports `./factory.js`). Built-in coverage works through it with correct source maps. The published artifact (`dist/*.js` and `dist/*.d.ts`) uses `.js` imports throughout; no `.ts` extensions ship.