### PR TITLE
ci: tune dependabot and add node 26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,19 @@
-# Basic dependabot.yml file with
-# minimum configuration for two package managers
-
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
-  # Enable updates to github actions
+      interval: "weekly"
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/fresh-deps.yml
+++ b/.github/workflows/fresh-deps.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [22, 24]
+        node: [22, 24, 26]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Moves Dependabot to weekly grouped updates and adds Node 26 to the CI matrices.

## Changes
- Dependabot: npm and github-actions updates go from daily to weekly, each ecosystem grouped into a single PR, and `@types/node` majors are ignored (it tracks the engines floor, not latest).
- Add Node 26 to the matrix in both the PR test workflow and the fresh-deps workflow (now 22, 24, 26).

## Verification
Config-only; the gate (`npm test`, `npm run coverage`, `npm run test:pack`) passes locally on Node 22. CI exercises 24 and 26.