### PR TITLE
chore: packaging and repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+coverage
+*.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.github/
-tests/
-axe.png
-example.ts

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint": "biome check .",
     "postrelease": "git push --follow-tags && npm publish",
     "prebuild": "rm -rf dist",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "prerelease": "git fetch --tags && npm test && npm run test:pack",
     "release": "npm version patch",
     "test": "npm run lint && npm run typecheck && npm run build && node --test --import=tsx test/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:watch": "node --test --watch --import=tsx test/*.test.ts",
     "typecheck": "tsc -p tsconfig.test.json"
   },
+  "sideEffects": false,
   "type": "module",
   "types": "dist/index.d.ts"
 }

--- a/scripts/test-pack.sh
+++ b/scripts/test-pack.sh
@@ -8,6 +8,9 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 cd "$root"
+# Build first, the way `prepublishOnly` does at publish time, so the tarball
+# carries a fresh dist (npm pack does not run prepublishOnly).
+npm run build >/dev/null 2>&1
 tarball="$tmp/$(npm pack --pack-destination "$tmp" 2>/dev/null | tail -1)"
 
 cd "$tmp"


### PR DESCRIPTION
Small packaging and repo cleanups: drop a dead ignore file, tidy `.gitignore`, mark the package side-effect free, and build at publish time instead of on every install.

## Changes
- Remove `.npmignore`. The `files` allowlist already governs the tarball, and the file referenced paths that no longer exist (`tests/`, `example.ts`).
- `.gitignore`: add `coverage` and `*.log`.
- Add `sideEffects: false` so bundlers can tree-shake; importing hyperaxe has no import-time side effects.
- Switch `prepare` to `prepublishOnly` so the build runs ahead of publish, not on every install. Since `prepublishOnly` does not run on `npm pack`, `test-pack.sh` now builds first so it still packs a fresh `dist`.

## Verification
`npm test`, `npm run coverage` (100%), and `npm run test:pack` (from a clean tree) pass locally.