### PR TITLE
fix: ship only dist and raise the node floor to 22.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     }
   },
   "files": [
-    "dist",
-    "src",
-    "!src/**/*.spec.ts"
+    "dist"
   ],
   "homepage": "https://github.com/ungoldman/hyperaxe#readme",
   "keywords": [


### PR DESCRIPTION
Two user-facing packaging fixes. This is the first change release-please will release.

## Changes
- Ship only `dist` in the published package. The exports map exposes just the entry and the `factory` subpath, both resolved from `dist`, so the TypeScript source no longer ships. Smaller install. (README, LICENSE, and package.json are included by npm regardless.)
- Raise the engines floor from `>=22` to `>=22.12.0`, where `require()` of a synchronous ES module is unflagged — the path a CommonJS consumer uses to load this ESM-only package.

## Verification
`npm test`, `npm run coverage` (100%), and `npm run test:pack` pass locally. `npm pack --dry-run` confirms the tarball is `dist/*` + README + LICENSE + package.json, no `src`.

Both are `fix:`, so on merge release-please opens a release PR for 3.0.2. Merging that release PR is what tags, releases, and publishes to npm via OIDC.