### PR TITLE
chore: cover test files in default tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "url": "git+https://github.com/ungoldman/hyperaxe.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "coverage": "node --test --experimental-test-coverage --import=tsx --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts",
     "format": "biome check --write .",
     "lint": "biome check .",
@@ -63,7 +63,7 @@
     "test": "npm run lint && npm run typecheck && npm run build && node --test --import=tsx test/*.test.ts",
     "test:pack": "bash scripts/test-pack.sh",
     "test:watch": "node --test --watch --import=tsx test/*.test.ts",
-    "typecheck": "tsc -p tsconfig.test.json"
+    "typecheck": "tsc"
   },
   "sideEffects": false,
   "type": "module",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "lib": ["es2022", "dom"],
     "allowJs": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true,
+    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -18,7 +16,9 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": ".",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
-}


### PR DESCRIPTION
## What this does

Makes the auto-discovered `tsconfig.json` cover both `src` and `test`, so the VS Code TS language server type-checks test files correctly.

The editor walks up from a test file and resolves the default-named `tsconfig.json`. That was the build config (`include: ["src"]`), so test files fell outside the include and landed in an inferred project with no `@types/node` and wrong module settings, producing spurious errors on test files (e.g. `Cannot find name 'node:assert/strict'`). `npm run typecheck` was clean only because it explicitly passed `-p tsconfig.test.json`, which the editor never auto-discovers.

This flips which config is the default: `tsconfig.json` becomes the editor/typecheck config covering `src` and `test`, and a new `tsconfig.build.json` emits dist from `src` only. The published package is byte-identical.

## Changes

- `tsconfig.json` is now standalone (no `extends`): `include: ["src", "test"]`, `noEmit`, `rootDir: "."`, `types: ["node"]`. Inlines the compiler options the test config used to inherit; emit-only options moved to the build config.
- New `tsconfig.build.json`: `extends: "./tsconfig.json"`, `include: ["src"]`, overrides `noEmit: false`, `rootDir: "src"`, `outDir: "dist"`, `declaration: true`. Emits exactly what the old `tsconfig.json` did.
- Delete `tsconfig.test.json` (folded into `tsconfig.json`).
- `package.json` scripts: `build` -> `tsc -p tsconfig.build.json`; `typecheck` -> `tsc`.

## Verification

- `npm run build` -> same four dist files as before (`index`/`factory`, `.js` + `.d.ts`), all byte-identical, no test files emitted.
- `npm run typecheck` -> passes; `tsc -p tsconfig.json --listFilesOnly` now includes `test/index.test.ts`.
- `npm test` -> 13 passing.
- `npm run test:pack` -> runtime import + type resolution ok.